### PR TITLE
Remove trailing comma in csv export

### DIFF
--- a/game/client/bg3/bg3_soft_info.cpp
+++ b/game/client/bg3/bg3_soft_info.cpp
@@ -166,7 +166,6 @@ CON_COMMAND(csv_export, "Generates a CSV inside a \'csv\' folder containing curr
 
 			//ping
 			buffer.PutInt(g_PR->GetPing(i));
-			buffer.PutChar(',');
 
 			//line delimiter
 			buffer.PutChar('\n');


### PR DESCRIPTION
CSV files don't need a comma at the end of a row