### PR TITLE
Add a setting to automatically export scores at map end

### DIFF
--- a/game/client/bg2/vgui_bg2_options.h
+++ b/game/client/bg2/vgui_bg2_options.h
@@ -24,7 +24,8 @@ extern ConVar	cl_crosshair,
 				cl_hitverif,
 				cl_hitdamageline,
 				cl_winmusic,
-				hud_takesshots;
+				hud_takesshots,
+				cl_auto_export_csv;
 
 
 class CBG2OptionsPanel : public vgui::Frame
@@ -70,6 +71,7 @@ class CBG2OptionsPanel : public vgui::Frame
 			cl_vcommsounds.SetValue( m_pVCommSoundsCheckButton->IsSelected() );
 			hud_takesshots.SetValue( m_pScreenShotCheckButton->IsSelected() );
 			hud_showtargetid.SetValue( m_pShowNamesCheckButton->IsSelected() );
+			cl_auto_export_csv.SetValue(m_pExportCsvCheckButton->IsSelected());
 		}
 
 		BaseClass::OnCommand( command );
@@ -109,6 +111,7 @@ class CBG2OptionsPanel : public vgui::Frame
 		m_pVCommSoundsCheckButton->SetSelected( cl_vcommsounds.GetBool() );
 		m_pScreenShotCheckButton->SetSelected( hud_takesshots.GetBool() );
 		m_pShowNamesCheckButton->SetSelected( hud_showtargetid.GetBool() );
+		m_pExportCsvCheckButton->SetSelected( cl_auto_export_csv.GetBool() );
 	}
 
 	/* CBG2OptionsPanel
@@ -177,6 +180,9 @@ class CBG2OptionsPanel : public vgui::Frame
 		m_pShowNamesCheckButton = new vgui::CheckButton( this, "ShowNamesCheckButton", "" );
 		m_pShowNamesCheckButton->AddActionSignalTarget( this );
 
+		m_pExportCsvCheckButton = new vgui::CheckButton(this, "AutoExportCheckButton", "");
+		m_pExportCsvCheckButton->AddActionSignalTarget(this);
+
 		//set sliders and checkboxes correctly
 		SetAdjustors();
 
@@ -220,7 +226,8 @@ class CBG2OptionsPanel : public vgui::Frame
 						*m_pVCommSoundsCheckButton,
 						*m_pShowNamesCheckButton,
 						*m_pWinmusicCheckButton,
-						*m_pScreenShotCheckButton;
+						*m_pScreenShotCheckButton,
+						*m_pExportCsvCheckButton;
 
 protected:
 	//virtual void OnCommand(const char *pCommand);

--- a/game/client/clientmode_shared.cpp
+++ b/game/client/clientmode_shared.cpp
@@ -80,6 +80,7 @@ ConVar cl_drawhud( "cl_drawhud", "1", 0, "Enable the rendering of the hud" ); //
 ConVar hud_takesshots( "hud_takesshots", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Auto-save a scoreboard screenshot at the end of a map." );
 ConVar hud_freezecamhide( "hud_freezecamhide", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Hide the HUD during freeze-cam" );
 ConVar cl_show_num_particle_systems( "cl_show_num_particle_systems", "0", FCVAR_CLIENTDLL, "Display the number of active particle systems." );
+ConVar cl_auto_export_csv("cl_auto_export_csv", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Auto export a scores CSV at the end of a map.");
 
 extern ConVar v_viewmodel_fov;
 extern ConVar voice_modenable;
@@ -256,6 +257,11 @@ static void __MsgFunc_VGUIMenu( bf_read &msg )
 		if ( hud_takesshots.GetBool() == true )
 		{
 			gHUD.SetScreenShotTime( gpGlobals->curtime + 1.0 ); // take a screenshot in 1 second
+		}
+
+		if (cl_auto_export_csv.GetBool() == true)
+		{
+			engine->ClientCmd("csv_export");
 		}
 	}
 


### PR DESCRIPTION
If this gets merged I have the changes ready for the BG3 options menu and the language files (the message has not been translated) I can apply to the game SVN.