### PR TITLE
Hide the beta weapons and menu icon

### DIFF
--- a/game/client/bg3/bg3_classmenu.cpp
+++ b/game/client/bg3/bg3_classmenu.cpp
@@ -1209,8 +1209,9 @@ CClassMenu::CClassMenu(vgui::VPANEL pParent) : Frame(NULL, PANEL_CLASSES) {
 	//Build TeamToggle and Close Buttons and Unlock Menu
 	m_pCloseButton = new CCloseButton(this, "ClassMenuCloseButton", MENU_CLOSE_ICON);
 	m_pTeamToggleButton = new CTeamToggleButton(MENU_TEAM_SWITCH_ICON);
+#ifdef BETA
 	m_pUnlockMenuButton = new CUnlockMenuButton(MENU_UNLOCK_MENU_ICON);
-
+#endif
 
 	//Be 100% sure that the runtime data we need from the classes has been initialized
 	//CPlayerClass::InitClientRunTimeData();
@@ -1548,8 +1549,10 @@ void CClassMenu::PerformLayout() {
 	m_pTeamToggleButton->SetPos(smlsz, 0);
 	m_pTeamToggleButton->SetSize(smlsz, smlsz);
 
+#ifdef BETA
 	m_pUnlockMenuButton->SetPos(smlsz * 2, 0);
 	m_pUnlockMenuButton->SetSize(smlsz, smlsz);
+#endif
 
 	//----------------------------------------------------------
 	//GLOBAL TEXTS

--- a/game/shared/bg3/bg3_class.cpp
+++ b/game/shared/bg3/bg3_class.cpp
@@ -448,7 +448,9 @@ DEC_BG3_PLAYER_CLASS(BInfantry, inf, b) {
 	m_aWeapons[0].m_pszWeaponPrimaryName = "weapon_brownbess";
 	m_aWeapons[1].m_pszWeaponPrimaryName = "weapon_longpattern";
 	m_aWeapons[2].m_pszWeaponPrimaryName = "weapon_sea_service";
+#ifdef BETA
 	m_aWeapons[3].m_pszWeaponPrimaryName = "weapon_oldpattern";
+#endif
 	m_aWeapons[2].m_iMovementSpeedModifier = 3;
 
 
@@ -530,10 +532,11 @@ DEC_BG3_PLAYER_CLASS(BNative, ski, b) {
 	m_aWeapons[2].m_pszWeaponPrimaryName = "weapon_club";
 	m_aWeapons[2].m_iMovementSpeedModifier = 5;
 
+#ifdef BETA
 	m_aWeapons[3].m_pszWeaponPrimaryName = "weapon_trade_musket";
 	m_aWeapons[3].m_pszWeaponSecondaryName = "weapon_knife";
 	m_aWeapons[3].m_iMovementSpeedModifier = -15;
-
+#endif
 
 	postClassConstruct(this);
 }
@@ -634,7 +637,9 @@ DEC_BG3_PLAYER_CLASS(AInfantry, inf, a) {
 	m_aWeapons[3].m_pszWeaponPrimaryName = "weapon_old_model_charleville";
 	m_aWeapons[4].m_pszWeaponPrimaryName = "weapon_dutch";
 	m_aWeapons[5].m_pszWeaponPrimaryName = "weapon_american_brownbess";
+#ifdef BETA
 	m_aWeapons[6].m_pszWeaponPrimaryName = "weapon_light_model_charleville";
+#endif
 
 	postClassConstruct(this);
 }
@@ -661,10 +666,15 @@ DEC_BG3_PLAYER_CLASS(AOfficer, off, a) {
 	m_aWeapons[0].m_pszWeaponSecondaryName = "weapon_sabre";
 	m_aWeapons[1].m_pszWeaponPrimaryName = "weapon_brownbess_carbine_nobayo";
 	m_aWeapons[1].m_pszWeaponSecondaryName = "weapon_sabre";
+
+#ifdef BETA
 	m_aWeapons[2].m_pszWeaponPrimaryName = "weapon_french_carbine";
 	m_aWeapons[2].m_pszWeaponSecondaryName = "weapon_sabre";
 
 	m_aWeapons[3].m_pszWeaponPrimaryName = "weapon_spontoon";
+#else
+	m_aWeapons[2].m_pszWeaponPrimaryName = "weapon_spontoon";
+#endif
 
 	postClassConstruct(this);
 }
@@ -724,8 +734,10 @@ DEC_BG3_PLAYER_CLASS(AMilitia, ski, a) {
 	m_aWeapons[2].m_pszPlayerModelOverrideName = MODEL_ASTATEMILITIA; //BG3 - minuteman/state class merge
 	m_aWeapons[2].m_iSleeveSkinOverride = SLEEVE_ASTATEMILITIA;
 
+#ifdef BETA
 	m_aWeapons[3].m_pszWeaponPrimaryName = "weapon_blunderbuss";
 	m_aWeapons[3].m_pszWeaponSecondaryName = "weapon_dagger";
+#endif
 
 #ifdef CLIENT_DLL
 	m_aWeapons[2].SetLocalizedName("weapon_longpattern_state");


### PR DESCRIPTION
I have hidden the "beta" features behind pre processor checks

To include the beta features in your builds add `BETA` to "Preprocessor Definitions" list here:
 ![image](https://user-images.githubusercontent.com/3164224/100624582-85fcc180-331b-11eb-9af9-bdf28f65020e.png)
